### PR TITLE
fix: adding flag optionally only if supported

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,7 +2,10 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.flag("-Wno-unused-but-set-variable").flag("-Wno-unused-value").flag("-Wno-implicit-fallthrough");
+    c_config
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-unused-value")
+        .flag_if_supported("-Wno-implicit-fallthrough");
     c_config.std("c11").include(src_dir);
 
     let parser_path = src_dir.join("parser.c");


### PR DESCRIPTION
Flags should be set only on compilers that support them.