### PR TITLE
Update to tree-sitter 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = ">=0.21.0"
+tree-sitter-language = "0.1.0"
 
 [build-dependencies]
-cc = "1.0.92"
+cc = "1.1.15"
+[dev-dependencies]
+tree-sitter = "0.23"

--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -3,13 +3,13 @@ package tree_sitter_yaml_test
 import (
 	"testing"
 
-	tree_sitter "github.com/smacker/go-tree-sitter"
-	"github.com/tree-sitter/tree-sitter-yaml"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_yaml "github.com/tree-sitter/tree-sitter-yaml/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {
 	language := tree_sitter.NewLanguage(tree_sitter_yaml.Language())
 	if language == nil {
-		t.Errorf("Error loading YAML grammar")
+		t.Errorf("Error loading Yaml grammar")
 	}
 }

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,5 +1,0 @@
-module github.com/tree-sitter-grammars/tree-sitter-yaml
-
-go 1.22
-
-require github.com/smacker/go-tree-sitter v0.0.0-20230720070738-0d0a9f78d8f8

--- a/bindings/python/tree_sitter_yaml/binding.c
+++ b/bindings/python/tree_sitter_yaml/binding.c
@@ -4,8 +4,8 @@ typedef struct TSLanguage TSLanguage;
 
 TSLanguage *tree_sitter_yaml(void);
 
-static PyObject* _binding_language(PyObject *self, PyObject *args) {
-    return PyLong_FromVoidPtr(tree_sitter_yaml());
+static PyObject* _binding_language(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args)) {
+    return PyCapsule_New(tree_sitter_yaml(), "tree_sitter.Language", NULL);
 }
 
 static PyMethodDef methods[] = {

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,6 +1,6 @@
 //! This crate provides YAML language support for the [tree-sitter][] parsing library.
 //!
-//! Typically, you will use the [language][language func] function to add this language to a
+//! Typically, you will use the `LANGUAGE` constant to add this language to a
 //! tree-sitter [Parser][], and then use the parser to parse some code:
 //!
 //! ```
@@ -11,28 +11,23 @@
 //!     - item2
 //! "#;
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(&tree_sitter_yaml::language()).expect("Error loading YAML grammar");
+//! parser.set_language(&tree_sitter_yaml::LANGUAGE.into()).expect("Error loading YAML grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! assert!(!tree.root_node().has_error());
 //! ```
 //!
-//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-//! [language func]: fn.language.html
+//! [LanguageFn]: https://docs.rs/tree-sitter-language/latest/tree_sitter_language/struct.LanguageFn.html
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_yaml() -> Language;
+    fn tree_sitter_yaml() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
-///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_yaml() }
-}
+/// The tree-sitter [`LanguageFn`] for this grammar.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_yaml) };
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
@@ -48,7 +43,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(&super::language())
+            .set_language(&super::LANGUAGE.into())
             .expect("Error loading YAML grammar");
     }
 }

--- a/package.json
+++ b/package.json
@@ -49,11 +49,10 @@
     }
   },
   "scripts": {
-    "build": "tree-sitter generate --no-bindings",
-    "postbuild": "npm run --prefix schema/core build",
-    "test": "tree-sitter test",
     "install": "node-gyp-build",
-    "prebuildify": "prebuildify --napi --strip"
+    "prestart": "tree-sitter build --wasm",
+    "start": "tree-sitter playground",
+    "test": "node --test bindings/node/*_test.js"
   },
   "publishConfig": {
     "access": "public"

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -47,6 +47,7 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {


### PR DESCRIPTION
Tree-sitter 0.23 has some breaking changes which require an update of the Rust bindings. This PR attempts to do that.