### PR TITLE
Fix `bindings/c/tree-sitter-yaml.h: No such file or directory`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,11 @@ add_library(tree-sitter-yaml src/parser.c)
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/scanner.c)
   target_sources(tree-sitter-yaml PRIVATE src/scanner.c)
 endif()
-target_include_directories(tree-sitter-yaml PRIVATE src)
+target_include_directories(tree-sitter-yaml
+                           PRIVATE src
+                           INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/bindings/c>
+                                     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
 
 set(YAML_SCHEMA core CACHE STRING "YAML schema")
 set(YAML_SCHEMA_VALUES core json legacy CACHE INTERNAL "Allowed schemas")
@@ -54,8 +58,9 @@ configure_file(bindings/c/tree-sitter-yaml.pc.in
 
 include(GNUInstallDirs)
 
-install(FILES bindings/c/tree-sitter-yaml.h
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tree_sitter")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bindings/c/tree_sitter"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+        FILES_MATCHING PATTERN "*.h")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-yaml.pc"
         DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig")
 install(TARGETS tree-sitter-yaml

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ $(PARSER): $(SRC_DIR)/grammar.json
 
 install: all
 	install -d '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/yaml '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'
-	install -m644 bindings/c/$(LANGUAGE_NAME).h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h
+	install -m644 bindings/c/tree_sitter/$(LANGUAGE_NAME).h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h
 	install -m644 $(LANGUAGE_NAME).pc '$(DESTDIR)$(PCLIBDIR)'/$(LANGUAGE_NAME).pc
 	install -m644 lib$(LANGUAGE_NAME).a '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).a
 	install -m755 lib$(LANGUAGE_NAME).$(SOEXT) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER)


### PR DESCRIPTION
This commit is the result of running:

```bash
tree-sitter init -u
```

It should fix the following failure when running `make install`:

```console
+ /usr/bin/make install DESTDIR=/builddir/build/BUILD/tree-sitter-yaml-0.7.1-build/BUILDROOT 'INSTALL=/usr/bin/install -p' PREFIX=/usr INCLUDEDIR=/usr/include LIBDIR=/usr/lib64
install -d '/builddir/build/BUILD/tree-sitter-yaml-0.7.1-build/BUILDROOT/usr/share'/tree-sitter/queries/yaml '/builddir/build/BUILD/tree-sitter-yaml-0.7.1-build/BUILDROOT/usr/include'/tree_sitter '/builddir/build/BUILD/tree-sitter-yaml-0.7.1-build/BUILDROOT/usr/lib64/pkgconfig' '/builddir/build/BUILD/tree-sitter-yaml-0.7.1-build/BUILDROOT/usr/lib64'
install -m644 bindings/c/tree-sitter-yaml.h '/builddir/build/BUILD/tree-sitter-yaml-0.7.1-build/BUILDROOT/usr/include'/tree_sitter/tree-sitter-yaml.h
install: cannot stat 'bindings/c/tree-sitter-yaml.h': No such file or directory
make: *** [Makefile:80: install] Error 1
```