### PR TITLE
Update sources in Package.swift to include all files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,6 @@
 import Foundation
 import PackageDescription
 
-var sources = ["src/parser.c"]
-if FileManager.default.fileExists(atPath: "src/scanner.c") {
-    sources.append("src/scanner.c")
-}
-
 let package = Package(
     name: "TreeSitterYAML",
     products: [
@@ -21,7 +16,13 @@ let package = Package(
             name: "TreeSitterYAML",
             dependencies: [],
             path: ".",
-            sources: sources,
+            sources: [
+                "src/parser.c",
+                "src/scanner.c",
+                "src/schema.core.c",
+                "src/schema.json.c",
+                "src/schema.legacy.c"
+            ],
             resources: [
                 .copy("queries")
             ],


### PR DESCRIPTION
## Description

This PR fixes a critical build issue when using this repository as a remote dependency via Swift Package Manager (SwiftPM).

## The Issue

Currently, `Package.swift` uses `FileManager.default.fileExists(atPath: "src/scanner.c")` to conditionally append the scanner to the `sources` array. However, there is a known limitation with SwiftPM: when this package is included as a dependency in another project, SwiftPM evaluates relative paths based on the **root project's working directory**, not the dependency's directory. 

Because of this, `fileExists` returns `false`, causing the scanner to be entirely omitted from the compilation process. This ultimately results in `Undefined symbols for architecture... _external_scanner_...` linker errors in downstream projects.

## The Fix

* Removed the dynamic `FileManager` check.
* Explicitly declared `src/scanner.c` (and other required source files) in the `sources` array of the target.
* Explicitly declared src/scanner.c, src/schema.core.c, src/schema.json.c, and src/schema.legacy.c in the sources array.
* 
This simple change ensures the package compiles correctly and links all required symbols regardless of how or where it is integrated via SwiftPM.